### PR TITLE
Fix parsing for epoch numbers

### DIFF
--- a/src/prototype.py
+++ b/src/prototype.py
@@ -7,7 +7,7 @@ import tempfile
 import docker
 from paramiko import SSHClient
 
-from dependencygraph import filter_non_dependencies
+#from dependencygraph import filter_non_dependencies
 
 
 
@@ -84,7 +84,7 @@ class SystemAnalyzer:
         self.image = self.docker_client.images.pull(f"{operating_sys}:{version}")
         logging.info(f"Pulled {self.image} from Docker hub.")
 
-
+    @staticmethod
     def parse_pkg_line(line):
         #assumes line comes in as something like 'curl.x86_64   [1:]7.29.0-42.el7'
         name = line.strip().split()[0] #curl.x86_64
@@ -170,9 +170,9 @@ class SystemAnalyzer:
         logging.info(f"Blacklisting defaults cut down {len(self.packages)} packages to {len(nondefault_packages)}")
 
         # Filter packages to exploit dependency relationships
-        self.filtered_packages = filter_non_dependencies(nondefault_packages, self.get_dependencies)
-        logging.info(f"Filtering by dependency further cut down {len(nondefault_packages)} packages to {len(self.filtered_packages)}")
-        # self.filtered_packages = just_packages
+        #self.filtered_packages = filter_non_dependencies(nondefault_packages, self.get_dependencies)
+        #logging.info(f"Filtering by dependency further cut down {len(nondefault_packages)} packages to {len(self.filtered_packages)}")
+        self.filtered_packages = just_packages
 
         # Determine packages to erase from base image
         self.extra_packages = default_packages - just_packages

--- a/src/prototype.py
+++ b/src/prototype.py
@@ -85,7 +85,7 @@ class SystemAnalyzer:
         logging.info(f"Pulled {self.image} from Docker hub.")
 
 
-    def parse_pkg_line(self, line):
+    def parse_pkg_line(line):
         #assumes line comes in as something like 'curl.x86_64   [1:]7.29.0-42.el7'
         name = line.strip().split()[0] #curl.x86_64
         name = name.split('.')[0]   #curl

--- a/src/prototype.py
+++ b/src/prototype.py
@@ -85,6 +85,16 @@ class SystemAnalyzer:
         logging.info(f"Pulled {self.image} from Docker hub.")
 
 
+    def parse_pkg_line(self, line):
+        #assumes line comes in as something like 'curl.x86_64   [1:]7.29.0-42.el7'
+        name = line.strip().split()[0] #curl.x86_64
+        name = name.split('.')[0]   #curl
+        ver = line.strip().split()[1] #1:7.29.0-42.el7
+        ver = ver.split('-')[0]    #1:7.29.0
+        if (':' in ver):
+            ver = ver.split(':')[1] #7.29.0
+        return (name, ver)
+
     def get_packages(self):
         logging.info("Getting packages...")
         while self.operating_sys == None:
@@ -96,11 +106,7 @@ class SystemAnalyzer:
             passedChaff = False;
             for line in stdout:
                 if (passedChaff):
-                    #parse line
-                    pkgName = line.strip().split()[0] #curl.x86_64
-                    pkgName = pkgName.split('.')[0]   #curl
-                    pkgVer = line.strip().split()[1] #7.29.0-42.el7
-                    pkgVer = pkgVer.split('-')[0]    #7.29.0
+                    pkgName, pkgVer = self.parse_pkg_line(line)
                     self.packages[pkgName] = pkgVer
                 elif (re.match(r'Installed Packages', line)):
                         passedChaff = True

--- a/test/test_pkgparsing.py
+++ b/test/test_pkgparsing.py
@@ -1,0 +1,20 @@
+# from src.prototype import parse_pkg_line
+from src.prototype import SystemAnalyzer
+
+def test_basic_parse():
+    '''
+    Test that lines of the form 'curl.x86_64   7.29.0-42.el7' are parsed correctly
+    '''
+    line = 'curl.x86_64   7.29.0-42.el7'
+    pkgName, pkgVersion  = SystemAnalyzer.parse_pkg_line(line)
+    assert pkgName == 'curl'
+    assert pkgVersion == '7.29.0'
+
+def test_epoch_parse():
+    '''
+    Test that epoch numbers dont mess with parsing 'curl.x86_64   1:7.29.0-42.el7'
+    '''
+    line = 'curl.x86_64   1:7.29.0-42.el7'
+    pkgName, pkgVersion  = SystemAnalyzer.parse_pkg_line(line)
+    assert pkgName == 'curl'               
+    assert pkgVersion == '7.29.0'

--- a/test/test_pkgparsing.py
+++ b/test/test_pkgparsing.py
@@ -1,4 +1,3 @@
-# from src.prototype import parse_pkg_line
 from src.prototype import SystemAnalyzer
 
 def test_basic_parse():


### PR DESCRIPTION
parsing now ignores epoch numbers in package versions. Also adds a test for parsing package names and versions.